### PR TITLE
投票機能の修正+α

### DIFF
--- a/src/routes/organizer/[room_id]/+page.svelte
+++ b/src/routes/organizer/[room_id]/+page.svelte
@@ -24,6 +24,7 @@
 		text: string;
 		options: string[];
 		results: number[];
+		open: boolean;
 	}
 
 	let commentList: Comment[] = [];
@@ -48,6 +49,7 @@
 			text: question,
 			options: options,
 			results: results,
+			open: true,
 		};
 		try {
 			await addDoc(collection(db, `Rooms/${room_id}/Questions`), questionData);
@@ -94,7 +96,7 @@
 				<FlowingComment text={comment.text}/>
 			{/if}
 		{/each}
-		</div>
+	</div>
 	<button 
 	type="submit" 
 	on:click={() => showModal = true}

--- a/src/routes/room/[room_id]/+page.svelte
+++ b/src/routes/room/[room_id]/+page.svelte
@@ -17,9 +17,11 @@
 
 	let text: string = "";
 	let time: Date;
-	let Message: string = "";
-	let chosen: number;
-	let disabled: string = "";
+	let message = {};
+	let chosen = {};
+	let disabled = {};
+	let hidden = {};
+
 	
 	// Reactive assignment
     const room_id: string = $page.params.room_id;
@@ -41,8 +43,9 @@
     type Question = {
         id?: string;
         text: string;
-        options: Array;
-		results: Array;
+        options: Array<string>;
+		results: Array<number>;
+		open: boolean;
     }
     let questions: Question[] = [];
 
@@ -74,23 +77,31 @@
                     text: data.text,
 					options: data.options,
 					results: data.results,
+					open: data.open,
                 };
+				const id:string = doc.id;
+				if(!(id in message)) message[id] = " ";
+				if(!(id in chosen)) chosen[id] = -1;
+				if(!(id in disabled)) disabled[id] = "";
+				if(!(id in hidden)) hidden[id] = "block";
                 return item;
             });
         }
     );
 	const vote = (question_id: string, q_index: number) => {
-		if (chosen === undefined) {
-			Message = "答えを選択してください．";
+		let chosenIndex = chosen[question_id];
+		if (chosenIndex === -1) {
+			message[question_id] = "答えを選択してください．";
 		} else { 
-			Message = "";
-			let cnt = questions[q_index]["results"][chosen];
+			message[question_id] = "";
+			let cnt = questions[q_index]["results"][chosenIndex];
 			let renew = questions[q_index]["results"];
-			renew[chosen] = ++cnt;
+			renew[chosenIndex] = ++cnt;
 			try {
-				const docRef = updateDoc(doc(db, `Rooms/${room_id}/Questions`, `${question_id}`), {"results": renew});//{options: renew}
-				disabled = "disabled";
-				Message = "投票完了";
+				const docRef = updateDoc(doc(db, `Rooms/${room_id}/Questions`, `${question_id}`), {"results": renew});
+				disabled[question_id] = "disabled";
+				hidden[question_id] = "hidden";
+				message[question_id] = "投票完了";
 			} catch (e) {
 				console.error("Error adding document: ", e);
 			}
@@ -103,36 +114,38 @@
     <meta name="description" content="About this app" />
 </svelte:head>
 
-<div class>
+<div class="p-8">
 	<h2 class="mb-4 font-bold text-center">Questions accepting answer</h2>
 	<div class="mx-auto max-w-lg my-4">
-		<div class="divide-y divide-gray-100">
-		{#each questions as question, q_index}
-		<details class="group rounded-lg bg-gray-50 border border-gray-300 my-2">
-			<summary class="flex cursor-pointer list-none items-center justify-between p-4 pl-6 font-noto font-medium text-secondary-900">
-				{question.text}
-				<div class="text-secondary-500">
-					<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="block h-5 w-5 transition-all duration-300 group-open:rotate-180">
-						<path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-					</svg>
+		<div>
+			{#each questions as question, q_index}
+			{#if question.open}
+			<details class="group rounded-lg bg-gray-50 border border-gray-300 my-2">
+				<summary class="flex cursor-pointer list-none items-center justify-between p-4 pl-6 font-noto font-medium text-secondary-900">
+					{question.text}
+					<div class="text-secondary-500">
+						<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="block h-5 w-5 transition-all duration-300 group-open:rotate-180">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+						</svg>
+					</div>
+				</summary>
+				<div class="px-6 pb-3 text-secondary-500">
+				{#each question.options as option, index}
+					<div class="flex items-center space-x-2 rounded p-2 pl-6 hover:bg-gray-100 font-noto">
+						<input type="radio" name="{question.id}" id="{question.id}_{index}" value={index} bind:group={chosen[question.id]} disabled={disabled[question.id]} class="h-4 w-4 rounded-full border-gray-300 text-primary-600 shadow-sm focus:border-primary-300 focus:ring focus:ring-primary-200 focus:ring-opacity-50 focus:ring-offset-0 disabled:cursor-not-allowed disabled:text-gray-400">
+						<label for="{question.id}_{index}" class="flex w-full space-x-2 text-sm"> {option} </label>
+					</div>
+				{/each}
+				<div class="text-sm text-red-600 font-noto" style="padding: 10px 1rem; visibility: {message[question.id] ? "visible" : "hidden"}">{message[question.id]}</div>
+				<button on:click={() => vote(question.id, q_index)}
+					class="{hidden[question.id]} mb-4 block text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+				>
+					Vote
+				</button>
 				</div>
-			</summary>
-			<div class="px-6 pb-3 text-secondary-500">
-			{#each question.options as option, index}
-				<div class="flex items-center space-x-2 rounded p-2 pl-6 hover:bg-gray-100 font-noto">
-					<input type="radio" name="{question.id}" id={index} value={index} bind:group={chosen} {disabled} class="h-4 w-4 rounded-full border-gray-300 text-primary-600 shadow-sm focus:border-primary-300 focus:ring focus:ring-primary-200 focus:ring-opacity-50 focus:ring-offset-0 disabled:cursor-not-allowed disabled:text-gray-400">
-					<label for={index} class="flex w-full space-x-2 text-sm"> {option} </label>
-				</div>
+			</details>
+			{/if}
 			{/each}
-			<div class="text-sm text-red-600 font-noto pl-4" style="padding-bottom: 20px; visibility: {Message ? "visible" : "hidden"}">{Message}</div>
-			<button on:click={() => vote(question.id, q_index)} {disabled}
-				class="mb-4 block text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
-			>
-				Vote
-			</button>
-			</div>
-		</details>
-		{/each}
 		</div>
 	</div>
 


### PR DESCRIPTION
ゼミで悪戦苦闘していたバグ?の修正です．
- 変数をJSON形式にして，それぞれのQuestionで表示するエラーメッセージや選択肢を独立させてます．
- 投票ボタンを押したら，ラジオボタンは `disabled` に，投票ボタンは `hidden` にしてます．
- データベースのQuestionの中に `open` フィールドを作成するようにしてます．`open=true` のQuestionのみ，Audience側に表示します．

## TODO
- local Storage を使って投票したか記憶する機能は実装できてません．（優先順位は低め? できたらしたいけど，投票の修正機能とか必要になる...?）
- organizerの画面で，Questionを投票締め切りにする（i.e. `open=false` にする）機能を付けたい．